### PR TITLE
alloc: Remove one unnecessary checking in memsec::_malloc()

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -94,9 +94,6 @@ unsafe fn _malloc<T>(size: usize) -> Option<*mut T> {
     if size >= ::std::usize::MAX - PAGE_SIZE * 4 {
         return None;
     }
-    if PAGE_SIZE <= mem::size_of_val(&CANARY) || PAGE_SIZE < mem::size_of::<usize>() {
-        abort();
-    }
 
     // aligned alloc ptr
     let size_with_canary = mem::size_of_val(&CANARY) + size;


### PR DESCRIPTION
We already check whether PAGE_SIZE in alloc_init(), and PAGE_SIZE
won't change after alloc_init(). So no need to recheck that in
_malloc().

Signed-off-by: Boqun Feng <boqun.feng@gmail.com>