### PR TITLE
build: Make memsec buildable by stable rust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#![feature(core_intrinsics)]
-#![feature(stmt_expr_attributes)]
-
 extern crate rand;
 #[cfg(unix)] extern crate libc;
 #[cfg(windows)] extern crate winapi;
@@ -47,8 +44,12 @@ pub unsafe fn memset<T>(s: *mut T, c: i32, n: usize) {
             -> mach_o_sys::ranlib::errno_t;
     }
 
-    if n > 0 && memset_s(s as *mut libc::c_void, n as mach_o_sys::ranlib::rsize_t, c, n as mach_o_sys::ranlib::rsize_t) != 0 {
-        std::intrinsics::abort();
+    if n > 0 {
+        let ret = memset_s(s as *mut libc::c_void, n as mach_o_sys::ranlib::rsize_t, c, n as mach_o_sys::ranlib::rsize_t);
+
+        if (ret != 0) {
+            panic!("memset_s return with error value {}", ret);
+        }
     }
 }
 


### PR DESCRIPTION
Remove two unstable features: core_intrinsics and stmt_expr_attributes,
so that the project could be built by stable rust. Two modifications are
done to achieve this:

1.	Use a helper function to get the page size on different
	platforms.

2.	Replace std::intrinsics::abort() with panic!() for fatal errors.

Though, running benchmark still needs nightly rust.

Not tested on Windows.

Signed-off-by: Boqun Feng <boqun.feng@gmail.com>