### PR TITLE
Add memory page size alignment for madvise, mlock and munlock

### DIFF
--- a/src/mlock.rs
+++ b/src/mlock.rs
@@ -2,6 +2,16 @@
 
 #![cfg(feature = "use_os")]
 
+use libc::_SC_PAGESIZE;
+
+/// Retrieve page size of the system
+///
+/// Used for alignment
+unsafe fn page_size() -> usize {
+    use libc::sysconf;
+    sysconf(_SC_PAGESIZE) as usize
+}
+
 /// Cross-platform `mlock`.
 ///
 /// * Unix `mlock`.
@@ -9,13 +19,33 @@
 pub unsafe fn mlock(addr: *mut u8, len: usize) -> bool {
     #[cfg(unix)]
     {
+        let page_size = page_size();
+
+        // start address of the page obtained from masked the value of the page size
+        // with the memory address
+        //
+        let start_addr = (addr as usize) & !(page_size - 1);
+
+        // End address of the page
+        let end_addr = ((addr as usize) + len + page_size - 1) & !(page_size - 1);
+
+        let aligned_len = end_addr - start_addr;
+
         #[cfg(target_os = "linux")]
-        libc::madvise(addr as *mut libc::c_void, len, libc::MADV_DONTDUMP);
+        libc::madvise(
+            start_addr as *mut libc::c_void,
+            aligned_len,
+            libc::MADV_DONTDUMP,
+        );
 
         #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
-        libc::madvise(addr as *mut libc::c_void, len, libc::MADV_NOCORE);
+        libc::madvise(
+            start_addr as *mut libc::c_void,
+            aligned_len,
+            libc::MADV_NOCORE,
+        );
 
-        libc::mlock(addr as *mut libc::c_void, len) == 0
+        libc::mlock(start_addr as *mut libc::c_void, aligned_len) == 0
     }
 
     #[cfg(windows)]
@@ -33,13 +63,32 @@ pub unsafe fn munlock(addr: *mut u8, len: usize) -> bool {
 
     #[cfg(unix)]
     {
+        let page_size = page_size();
+
+        // start address of the page obtained from masked the value of the page size
+        // with the memory address
+        //
+        let start_addr = (addr as usize) & !(page_size - 1);
+
+        // End address of the page
+        let end_addr = ((addr as usize) + len + page_size - 1) & !(page_size - 1);
+
+        let aligned_len = end_addr - start_addr;
         #[cfg(target_os = "linux")]
-        libc::madvise(addr as *mut libc::c_void, len, libc::MADV_DODUMP);
+        libc::madvise(
+            start_addr as *mut libc::c_void,
+            aligned_len,
+            libc::MADV_DODUMP,
+        );
 
         #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
-        libc::madvise(addr as *mut libc::c_void, len, libc::MADV_CORE);
+        libc::madvise(
+            start_addr as *mut libc::c_void,
+            aligned_len,
+            libc::MADV_CORE,
+        );
 
-        libc::munlock(addr as *mut libc::c_void, len) == 0
+        libc::munlock(start_addr as *mut libc::c_void, aligned_len) == 0
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
Improved memory alignment in mlock and munlock functions(including madvise) to ensure proper page boundary handling. This adjustment aligns memory regions to the system's page size across unix systems
