### PR TITLE
Fix testing on Windows and some lints

### DIFF
--- a/memsec-test/Cargo.toml
+++ b/memsec-test/Cargo.toml
@@ -12,7 +12,11 @@ default-features = false
 [dev-dependencies]
 libc = "0.2"
 quickcheck = "1"
-procspawn = {version = "1.0.0", features = ["test-support"]}
+procspawn = {version = "1.0.1", features = ["test-support"]}
+
+[target."cfg(windows)".dev-dependencies]
+# procspawn 1.0.1 is not enabling the Win32_Foundation feature, which causes compilation to fail
+windows-sys = { version = "0.48.0", features = ["Win32_System_Threading", "Win32_Foundation"] }
 
 [target.'cfg(unix)'.dev-dependencies]
 libsodium-sys = { version = "0.2" }

--- a/src/alloc/allocext/linux.rs
+++ b/src/alloc/allocext/linux.rs
@@ -67,6 +67,7 @@ unsafe fn _memfd_secret(size: usize) -> Option<*mut u8> {
 
     let canary_ptr = unprotected_ptr.add(unprotected_size - size_with_canary);
     let user_ptr = canary_ptr.add(CANARY_SIZE);
+    #[allow(static_mut_refs)]
     ptr::copy_nonoverlapping(CANARY.as_ptr(), canary_ptr, CANARY_SIZE);
     ptr::write_unaligned(base_ptr as *mut usize, unprotected_size);
     ptr::write_unaligned(fd_ptr as *mut libc::c_int, fd);
@@ -112,6 +113,7 @@ pub unsafe fn free_memfd_secret<T: ?Sized>(memptr: NonNull<T>) {
     let fd = ptr::read(fd_ptr);
 
     // check
+    #[allow(static_mut_refs)]
     if !crate::memeq(canary_ptr as *const u8, CANARY.as_ptr(), CANARY_SIZE) {
         abort();
     }

--- a/src/alloc/mod.rs
+++ b/src/alloc/mod.rs
@@ -173,6 +173,7 @@ unsafe fn _malloc(size: usize) -> Option<*mut u8> {
 
     let canary_ptr = unprotected_ptr.add(unprotected_size - size_with_canary);
     let user_ptr = canary_ptr.add(CANARY_SIZE);
+    #[allow(static_mut_refs)]
     ptr::copy_nonoverlapping(CANARY.as_ptr(), canary_ptr, CANARY_SIZE);
     ptr::write_unaligned(base_ptr as *mut usize, unprotected_size);
     _mprotect(base_ptr, PAGE_SIZE, Prot::ReadOnly);
@@ -211,6 +212,7 @@ pub unsafe fn free<T: ?Sized>(memptr: NonNull<T>) {
     let unprotected_size = ptr::read(base_ptr as *const usize);
 
     // check
+    #[allow(static_mut_refs)]
     if !crate::memeq(canary_ptr as *const u8, CANARY.as_ptr(), CANARY_SIZE) {
         abort();
     }


### PR DESCRIPTION
The `procspawn` crate is missing a `windows-sys` feature in the latest 1.0.1 release, which causes testing on Windows to fail. I've temporarily added the windows-sys crate as a dev-dependency to include this missing feature and also opened a PR upstream to fix it: https://github.com/mitsuhiko/procspawn/pull/53

I've also allowed some `static_mut_refs` lints that were failing the build when using a recent version of Rust